### PR TITLE
Increasing minutesInactive limit from 12 hours to 5 days.

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -58,8 +58,8 @@ define(['tabmanager'], function(tabmanager) {
    * @see Settings.set
    */
   Settings.setminutesInactive = function(value) {
-    if ( isNaN(parseInt(value, 10)) || parseInt(value, 10) <= 0 || parseInt(value, 10) > 720 ){
-      throw Error("Minutes Inactive must be greater than 0 and less than 720");
+    if ( isNaN(parseInt(value, 10)) || parseInt(value, 10) <= 0 || parseInt(value, 10) > 7200 ){
+      throw Error("Minutes Inactive must be greater than 0 and less than 7200");
     }
     // Reset the tabTimes since we changed the setting
     tabmanager.tabTimes = {};


### PR DESCRIPTION
12 hours is too short of a time limit for my needs (I want something more like 24 or 36 hours). This commit increases the limit to 5 days (7200 minutes). Alternatively, I suspect removing an upper limit altogether could be justified.
