### PR TITLE
remove duplicate closed tabs (by URL) when closing; keep youngest

### DIFF
--- a/js/tabmanager.js
+++ b/js/tabmanager.js
@@ -23,7 +23,7 @@ TabManager.updateLastAccessed = function (tabId) {
   if (typeof tabId == "object") {
     tabId = tabId.id;
   }
-  
+
   if (typeof tabId != 'number') {
     console.log('Error: ' + tabId.toString() + ' is not an number', tabId);
     return;
@@ -138,6 +138,11 @@ TabManager.closedTabs.save = function() {
   chrome.storage.local.set({savedTabs: this.tabs});
 };
 
+TabManager.closedTabs.removeDuplicates = function() {
+  // removes duplicate tabs (by URL), keeps youngest
+  this.tabs = _.uniq(this.tabs, false, function(t) { return t.url } );
+};
+
 TabManager.closedTabs.saveTabs = function(tabs) {
   var maxTabs = TW.settings.get('maxTabs');
   for (var i=0; i < tabs.length; i++) {
@@ -151,6 +156,7 @@ TabManager.closedTabs.saveTabs = function(tabs) {
   if ((this.tabs.length - maxTabs) > 0) {
     this.tabs = this.tabs.splice(0, maxTabs);
   }
+  TabManager.closedTabs.removeDuplicates();
   TabManager.closedTabs.save();
 };
 


### PR DESCRIPTION
Having quite a few tabs closed automatically, I'm getting the same tab (URL) closed again and again - so why not having the duplicates removed? Out of my closed tabs, about 10% were dupes until I added this fix.

The most recently closed one is kept, older ones are removed.

Should be fine to as an update for existing users as it checks all and not just the recently added ones.

Could be made an option as well, but I think it's a reasonable default handling.

Sorry for the spacing change and the newline at the end of the file. I recognized too late that my editor changed that.