### PR TITLE
Fix secondsToMinutes where seconds%60 is 10

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -32,7 +32,7 @@ Popup.Util.buildFaviconCol = function(url) {
 
 Popup.Util.secondsToMinutes =  function (seconds) {
   var s = seconds % 60;
-  s = s > 10 ? String(s) : "0" + String(s);
+  s = s >= 10 ? String(s) : "0" + String(s);
   return String(Math.floor(seconds / 60)) + ":" + s;
 };
 


### PR DESCRIPTION
Previously, it would print :010 instead of :10. 
